### PR TITLE
Add error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "cbindgen",
  "jni",
  "libc",
+ "log",
  "ohttp",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "jni",
  "libc",
  "ohttp",
+ "thiserror",
 ]
 
 [[package]]

--- a/apprelay/Cargo.toml
+++ b/apprelay/Cargo.toml
@@ -11,6 +11,7 @@ ohttp = { git = "https://github.com/chris-wood/ohttp-1", features = ["rust-hpke"
 libc = "0.2"
 
 thiserror = "1.0.32"
+log = "0.4.17"
 
 [dependencies.jni]
 version = "0.19.0"

--- a/apprelay/Cargo.toml
+++ b/apprelay/Cargo.toml
@@ -10,6 +10,8 @@ bytes = "1.2.0"
 ohttp = { git = "https://github.com/chris-wood/ohttp-1", features = ["rust-hpke", "client", "proto-http"], default-features = false, branch = "caw/add-custom-labels" }
 libc = "0.2"
 
+thiserror = "1.0.32"
+
 [dependencies.jni]
 version = "0.19.0"
 optional = true

--- a/apprelay/apprelay.h
+++ b/apprelay/apprelay.h
@@ -12,22 +12,83 @@ typedef struct ResponseContext ResponseContext;
 extern "C" {
 #endif // __cplusplus
 
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *request_context_message_ffi(struct RequestContext *context);
 
+// Return the number of bytes that the encapsulated request takes
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t request_context_message_len_ffi(struct RequestContext *context);
 
+// Return the pointer to first byte of decapsulated response
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *response_context_message_ffi(struct ResponseContext *context);
 
+// Return the number of bytes that the decapsulated response takes
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t response_context_message_len_ffi(struct ResponseContext *context);
 
+// Encapsulates the provided `encoded_msg` using `encoded_config`
+//
+// This function will return `null` pointer if:
+//     - creating the request context fails ie due to parsing errors of configuration
+//     - encapsulation fails ie due to failed hpke encryption
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_ptr,
                                                size_t encoded_config_len,
                                                const uint8_t *encoded_msg_ptr,
                                                size_t encoded_msg_len);
 
+// Decapsulates the provided `encapsulated_response` using `context`
+//
+// This function will return `null` pointer if:
+//     - decapsulation fails ie due to failed hpke encryption
+//
+// # Safety
+// This dereferences a raw pointer to `RequestContext` passed by user.
+// Be sure that the context has not been yet freed and that you are using valid pointer
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct ResponseContext *decapsulate_response_ffi(struct RequestContext *context,
                                                  const uint8_t *encapsulated_response_ptr,
                                                  size_t encapsulated_response_len);
+
+// Return the number of bytes in the last error message
+// Does not include any trailing null terminators
+int last_error_length(void);
+
+// Write most recent error UTF-8 encoded message into a provided buffer
+//
+// If there are no recent errors then this returns `0`
+// `-1` is returned if there is an error but something bad happened:
+//     - provided `buffer` is to small
+//     - or a provided `buffer` is a null pointer
+// Otherewise the function returnes the number of bytes written to buffer
+int last_error_message(char *buffer, int length);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/apprelay/apprelay.h
+++ b/apprelay/apprelay.h
@@ -12,11 +12,11 @@ typedef struct ResponseContext ResponseContext;
 extern "C" {
 #endif // __cplusplus
 
-// Return the pointer to first byte of encapsulated request.
+// Return a pointer to encapsulated request
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *request_context_message_ffi(struct RequestContext *context);
@@ -24,39 +24,51 @@ uint8_t *request_context_message_ffi(struct RequestContext *context);
 // Return the size in bytes of the encapsulated request.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t request_context_message_len_ffi(struct RequestContext *context);
 
+// Frees up context memory. Be sure to call this in cases:
+// - after encapsulating the HTTP request was not performed
+// - the response has not been returned or is not successful
+//
+// # Safety
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
+//
+// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
+void request_context_message_drop_ffi(struct RequestContext *context);
+
 // Return a pointer to the decapsulated response.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *response_context_message_ffi(struct ResponseContext *context);
 
-// Return the size in bytes of the decapsulated response.
+// Return size in bytes of the decapsulated response.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t response_context_message_len_ffi(struct ResponseContext *context);
 
-// Encapsulates the provided `encoded_msg` using `encoded_config`
+// Encapsulates the provided `encoded_msg` using `encoded_config` and returns
+// a context used for decapsulating the corresponding response.
 //
 // This function will return a NULL pointer if:
-//     - creating the request context fails due to input errors.
-//     - encapsulation fails.
+// - creating the request context fails due to input errors.
+// - encapsulation fails.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_ptr,
@@ -69,26 +81,17 @@ struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_ptr
 // This function will return a NULL pointer if decapsulation fails.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by the caller.
-// Be sure that the context has not been yet freed and that you are using valid pointer.
+// Dereferences a pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using a valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct ResponseContext *decapsulate_response_ffi(struct RequestContext *context,
                                                  const uint8_t *encapsulated_response_ptr,
                                                  size_t encapsulated_response_len);
 
-// Return the number of bytes in the last error message
-// Does not include any trailing null terminators
+// Return the number of bytes in the last error message.
+// Does not include any trailing null terminators.
 int last_error_length(void);
-
-// Write most recent error UTF-8 encoded message into a provided buffer
-//
-// If there are no recent errors then this returns `0`
-// `-1` is returned if there is an error but something bad happened:
-//     - provided `buffer` is to small
-//     - or a provided `buffer` is a null pointer
-// Otherwise the function returns the number of bytes written to buffer.
-int last_error_message(char *buffer, int length);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/apprelay/apprelay.h
+++ b/apprelay/apprelay.h
@@ -12,50 +12,51 @@ typedef struct ResponseContext ResponseContext;
 extern "C" {
 #endif // __cplusplus
 
+// Return the pointer to first byte of encapsulated request.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *request_context_message_ffi(struct RequestContext *context);
 
-// Return the number of bytes that the encapsulated request takes
+// Return the size in bytes of the encapsulated request.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t request_context_message_len_ffi(struct RequestContext *context);
 
-// Return the pointer to first byte of decapsulated response
+// Return a pointer to the decapsulated response.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 uint8_t *response_context_message_ffi(struct ResponseContext *context);
 
-// Return the number of bytes that the decapsulated response takes
+// Return the size in bytes of the decapsulated response.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t response_context_message_len_ffi(struct ResponseContext *context);
 
 // Encapsulates the provided `encoded_msg` using `encoded_config`
 //
-// This function will return `null` pointer if:
-//     - creating the request context fails ie due to parsing errors of configuration
-//     - encapsulation fails ie due to failed hpke encryption
+// This function will return a NULL pointer if:
+//     - creating the request context fails due to input errors.
+//     - encapsulation fails.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_ptr,
@@ -63,14 +64,13 @@ struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_ptr
                                                const uint8_t *encoded_msg_ptr,
                                                size_t encoded_msg_len);
 
-// Decapsulates the provided `encapsulated_response` using `context`
+// Decapsulates the provided `encapsulated_response` using `context`.
 //
-// This function will return `null` pointer if:
-//     - decapsulation fails ie due to failed hpke encryption
+// This function will return a NULL pointer if decapsulation fails.
 //
 // # Safety
-// This dereferences a raw pointer to `RequestContext` passed by user.
-// Be sure that the context has not been yet freed and that you are using valid pointer
+// This dereferences a raw pointer to `RequestContext` passed by the caller.
+// Be sure that the context has not been yet freed and that you are using valid pointer.
 //
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 struct ResponseContext *decapsulate_response_ffi(struct RequestContext *context,
@@ -87,7 +87,7 @@ int last_error_length(void);
 // `-1` is returned if there is an error but something bad happened:
 //     - provided `buffer` is to small
 //     - or a provided `buffer` is a null pointer
-// Otherewise the function returnes the number of bytes written to buffer
+// Otherwise the function returns the number of bytes written to buffer.
 int last_error_message(char *buffer, int length);
 
 #ifdef __cplusplus

--- a/apprelay/src/android.rs
+++ b/apprelay/src/android.rs
@@ -7,9 +7,9 @@ use jni::sys::{jbyteArray, jlong, jstring};
 use crate::error_ffi::update_last_error;
 use crate::{ClientError, RequestContext};
 
-/// Return most recent error as java `String`
+/// Return most recent error as a Java `String`.
 ///
-/// If the are no recent errors than this returns `null` pointer
+/// If the are no recent errors than this returns a NULL pointer.
 #[no_mangle]
 pub extern "system" fn Java_org_platform_OHttpNativeWrapper_lastErrorMessage(
     env: JNIEnv,
@@ -22,11 +22,9 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_lastErrorMessage(
     }
 }
 
-/// Encapsulates given request with provided configuration
+/// Encapsulates a request using the provided configuration.
 ///
-/// Returns a pointer to encapsulation context.
-/// If the provided values are null or function fails from other reason
-/// the return value will be `-1`
+/// Returns a pointer to encapsulation context, and returns -1 upon failure.
 #[no_mangle]
 pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
     env: JNIEnv,
@@ -67,15 +65,14 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
     }
 }
 
-/// Accesses the encapsulation result for given context
+/// Accesses the encapsulation result for given context.
 ///
-/// Returns an array containing encapsulated request ready for ohttp.
-///
-/// If the jni failes to create array the return value will be `-1`
+/// Returns an array containing an encapsulation request,
+/// or -1 upon failure.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -99,8 +96,8 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_getEncapsulat
 /// - the response has not been returned or is not successfull
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -115,14 +112,13 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_drop(
 /// Decapsulates the provided response `encapsulated_response` using
 /// requests config obtain by dereferencing `context_ptr`
 ///
-/// Returns an array containing decapsulated response
+/// Returns an array containing the decapsulated response.
 ///
-/// If this funtion failes due to jni problems or decapsulation
-/// it will return null pointer
+/// If this function fails due JNI problems or decapsulation it returns a NULL pointer.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]

--- a/apprelay/src/android.rs
+++ b/apprelay/src/android.rs
@@ -71,8 +71,8 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
 /// or -1 upon failure.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -92,12 +92,12 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_getEncapsulat
 }
 
 /// Frees up context memory. Be sure to call this in cases:
-/// - after encapsulating the http request was not performed
-/// - the response has not been returned or is not successfull
+/// - after encapsulating the HTTP request was not performed
+/// - the response has not been returned or is not successful
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -117,8 +117,8 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_drop(
 /// If this function fails due JNI problems or decapsulation it returns a NULL pointer.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]

--- a/apprelay/src/android.rs
+++ b/apprelay/src/android.rs
@@ -2,11 +2,31 @@ use jni::JNIEnv;
 
 use jni::objects::JClass;
 
-use jni::sys::{jbyteArray, jlong};
-use ohttp::ClientRequest;
+use jni::sys::{jbyteArray, jlong, jstring};
 
-use crate::RequestContext;
+use crate::error_ffi::update_last_error;
+use crate::{ClientError, RequestContext};
 
+/// Return most recent error as java `String`
+///
+/// If the are no recent errors than this returns `null` pointer
+#[no_mangle]
+pub extern "system" fn Java_org_platform_OHttpNativeWrapper_lastErrorMessage(
+    env: JNIEnv,
+    _class: JClass,
+) -> jstring {
+    let err = crate::error_ffi::take_last_error();
+    match err.map(|e| env.new_string(e.to_string())) {
+        Some(Ok(jstr)) => jstr.into_inner(),
+        _ => std::ptr::null_mut() as _,
+    }
+}
+
+/// Encapsulates given request with provided configuration
+///
+/// Returns a pointer to encapsulation context.
+/// If the provided values are null or function fails from other reason
+/// the return value will be `-1`
 #[no_mangle]
 pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
     env: JNIEnv,
@@ -14,18 +34,50 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
     config: jbyteArray,
     msg: jbyteArray,
 ) -> jlong {
-    // First, we have to get the byte[] out of java.
-    let config = env.convert_byte_array(config).unwrap();
-    let msg = env.convert_byte_array(msg).unwrap();
+    if config.is_null() {
+        update_last_error(ClientError::InvalidArgument("config".to_string()));
+        return -1;
+    }
 
-    let client = ClientRequest::new(&config[..]).unwrap();
-    let (enc_request, client_response) = client.encapsulate(&msg[..]).unwrap();
-    Box::into_raw(Box::new(RequestContext {
-        encapsulated_request: enc_request,
-        response_context: client_response,
-    })) as jlong
+    if msg.is_null() {
+        update_last_error(ClientError::InvalidArgument("msg".to_string()));
+        return -1;
+    }
+
+    // First, we have to get the byte[] out of java.
+    let config = match env.convert_byte_array(config) {
+        Ok(c) => c,
+        Err(err) => {
+            update_last_error(ClientError::JniProblem(err));
+            return -1;
+        }
+    };
+
+    let msg = match env.convert_byte_array(msg) {
+        Ok(c) => c,
+        Err(err) => {
+            update_last_error(ClientError::JniProblem(err));
+            return -1;
+        }
+    };
+
+    unsafe {
+        crate::encapsulate_request_ffi(config.as_ptr(), config.len(), msg.as_ptr(), msg.len())
+            as jlong
+    }
 }
 
+/// Accesses the encapsulation result for given context
+///
+/// Returns an array containing encapsulated request ready for ohttp.
+///
+/// If the jni failes to create array the return value will be `-1`
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_getEncapsulatedRequest(
     env: JNIEnv,
@@ -33,10 +85,24 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_getEncapsulat
     context_ptr: jlong,
 ) -> jbyteArray {
     let context = &mut *(context_ptr as *mut RequestContext);
-    env.byte_array_from_slice(&context.encapsulated_request[..])
-        .unwrap()
+    match env.byte_array_from_slice(&context.encapsulated_request[..]) {
+        Ok(req) => req,
+        Err(err) => {
+            update_last_error(ClientError::JniProblem(err));
+            std::ptr::null_mut() as _
+        }
+    }
 }
 
+/// Frees up context memory. Be sure to call this in cases:
+/// - after encapsulating the http request was not performed
+/// - the response has not been returned or is not successfull
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_drop(
     _env: JNIEnv,
@@ -46,6 +112,19 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_drop(
     let _context = Box::from_raw(context_ptr as *mut RequestContext);
 }
 
+/// Decapsulates the provided response `encapsulated_response` using
+/// requests config obtain by dereferencing `context_ptr`
+///
+/// Returns an array containing decapsulated response
+///
+/// If this funtion failes due to jni problems or decapsulation
+/// it will return null pointer
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_decapsulateResponse(
     env: JNIEnv,
@@ -54,10 +133,25 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_decapsulateRe
     encapsulated_response: jbyteArray,
 ) -> jbyteArray {
     let context = Box::from_raw(context_ptr as *mut RequestContext);
-    let encapsulated_response = env.convert_byte_array(encapsulated_response).unwrap();
-    let response = context
-        .response_context
-        .decapsulate(&encapsulated_response)
-        .unwrap();
-    env.byte_array_from_slice(&response[..]).unwrap()
+    let encapsulated_response = match env.convert_byte_array(encapsulated_response) {
+        Ok(rsp) => rsp,
+        Err(err) => {
+            update_last_error(ClientError::JniProblem(err));
+            return std::ptr::null_mut() as _;
+        }
+    };
+    let response = match context.response_context.decapsulate(&encapsulated_response) {
+        Ok(rsp) => rsp,
+        Err(err) => {
+            update_last_error(ClientError::DecapsulationFailed(err));
+            return std::ptr::null_mut();
+        }
+    };
+    match env.byte_array_from_slice(&response[..]) {
+        Ok(rsp) => rsp,
+        Err(err) => {
+            update_last_error(ClientError::JniProblem(err));
+            std::ptr::null_mut()
+        }
+    }
 }

--- a/apprelay/src/error_ffi.rs
+++ b/apprelay/src/error_ffi.rs
@@ -25,8 +25,8 @@ pub fn take_last_error() -> Option<Box<dyn Error>> {
     LAST_ERROR.with(|prev| prev.borrow_mut().take())
 }
 
-/// Return the number of bytes in the last error message
-/// Does not include any trailing null terminators
+/// Return the number of bytes in the last error message.
+/// Does not include any trailing null terminators.
 #[no_mangle]
 pub extern "C" fn last_error_length() -> libc::c_int {
     LAST_ERROR.with(|prev| match *prev.borrow() {
@@ -41,7 +41,7 @@ pub extern "C" fn last_error_length() -> libc::c_int {
 /// `-1` is returned if there is an error but something bad happened:
 ///     - provided `buffer` is to small
 ///     - or a provided `buffer` is a null pointer
-/// Otherewise the function returnes the number of bytes written to buffer
+/// Otherwise the function returns the number of bytes written to buffer.
 #[no_mangle]
 pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) -> c_int {
     if buffer.is_null() {

--- a/apprelay/src/error_ffi.rs
+++ b/apprelay/src/error_ffi.rs
@@ -1,18 +1,19 @@
 use std::{cell::RefCell, error::Error, slice};
 
 use libc::{c_char, c_int};
+use log::error;
 
 thread_local! {
     static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);
 }
 
+/// Update the last error, clearing the old one.
 pub fn update_last_error<E: Error + 'static>(err: E) {
-    eprintln!("Setting last error {err}");
-
+    error!("Setting last error {err}");
     {
         let mut cause = err.source();
         while let Some(parent_err) = cause {
-            eprintln!("Caused by: {parent_err}");
+            error!("Caused by: {parent_err}");
             cause = parent_err.source();
         }
     }
@@ -21,6 +22,7 @@ pub fn update_last_error<E: Error + 'static>(err: E) {
     });
 }
 
+/// Retrieve the most recent error, clearing it in the process.
 pub fn take_last_error() -> Option<Box<dyn Error>> {
     LAST_ERROR.with(|prev| prev.borrow_mut().take())
 }
@@ -35,17 +37,19 @@ pub extern "C" fn last_error_length() -> libc::c_int {
     })
 }
 
-/// Write most recent error UTF-8 encoded message into a provided buffer
+/// Write the most recent error UTF-8 encoded message into a provided buffer
 ///
-/// If there are no recent errors then this returns `0`
-/// `-1` is returned if there is an error but something bad happened:
-///     - provided `buffer` is to small
-///     - or a provided `buffer` is a null pointer
-/// Otherwise the function returns the number of bytes written to buffer.
-#[no_mangle]
+/// If there are no recent errors then this returns 0. -1 is returned if there is an error but something bad happened:
+/// - provided `buffer` is too small
+/// - or a provided `buffer` is a null pointer
+///
+/// Otherwise the function returns the number of bytes written to the buffer.
+///
+/// # Safety
+/// The invariants are described here [`from_raw_parts_mut`](std::slice::from_raw_parts_mut#safety)
 pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) -> c_int {
     if buffer.is_null() {
-        eprintln!("Null pointer passed into last_error_message() as the buffer");
+        error!("Null pointer passed into last_error_message() as the buffer");
         return -1;
     }
 
@@ -59,8 +63,8 @@ pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) 
     let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length as usize);
 
     if error_message.len() >= buffer.len() {
-        eprintln!("Buffer providded for writing last message is to small!");
-        eprintln!(
+        error!("Buffer providded for writing last message is to small!");
+        error!(
             "Expected at least {} bytes but got {}",
             error_message.len() + 1,
             buffer.len()

--- a/apprelay/src/error_ffi.rs
+++ b/apprelay/src/error_ffi.rs
@@ -1,0 +1,80 @@
+use std::{cell::RefCell, error::Error, slice};
+
+use libc::{c_char, c_int};
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);
+}
+
+pub fn update_last_error<E: Error + 'static>(err: E) {
+    eprintln!("Setting last error {err}");
+
+    {
+        let mut cause = err.source();
+        while let Some(parent_err) = cause {
+            eprintln!("Caused by: {parent_err}");
+            cause = parent_err.source();
+        }
+    }
+    LAST_ERROR.with(|prev| {
+        *prev.borrow_mut() = Some(Box::new(err));
+    });
+}
+
+pub fn take_last_error() -> Option<Box<dyn Error>> {
+    LAST_ERROR.with(|prev| prev.borrow_mut().take())
+}
+
+/// Return the number of bytes in the last error message
+/// Does not include any trailing null terminators
+#[no_mangle]
+pub extern "C" fn last_error_length() -> libc::c_int {
+    LAST_ERROR.with(|prev| match *prev.borrow() {
+        Some(ref err) => err.to_string().len() as libc::c_int,
+        None => 0,
+    })
+}
+
+/// Write most recent error UTF-8 encoded message into a provided buffer
+///
+/// If there are no recent errors then this returns `0`
+/// `-1` is returned if there is an error but something bad happened:
+///     - provided `buffer` is to small
+///     - or a provided `buffer` is a null pointer
+/// Otherewise the function returnes the number of bytes written to buffer
+#[no_mangle]
+pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) -> c_int {
+    if buffer.is_null() {
+        eprintln!("Null pointer passed into last_error_message() as the buffer");
+        return -1;
+    }
+
+    let last_error = match take_last_error() {
+        Some(err) => err,
+        None => return 0,
+    };
+
+    let error_message = last_error.to_string();
+
+    let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length as usize);
+
+    if error_message.len() >= buffer.len() {
+        eprintln!("Buffer providded for writing last message is to small!");
+        eprintln!(
+            "Expected at least {} bytes but got {}",
+            error_message.len() + 1,
+            buffer.len()
+        );
+        return -1;
+    }
+
+    std::ptr::copy_nonoverlapping(
+        error_message.as_ptr(),
+        buffer.as_mut_ptr(),
+        error_message.len(),
+    );
+
+    // Add a trailling null terminator
+    buffer[error_message.len()] = 0;
+    error_message.len() as c_int
+}

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -34,11 +34,11 @@ pub struct RequestContext {
     response_context: ClientResponse,
 }
 
-// Return the pointer to first byte of encapsulated request
+// Return a pointer to encapsulated request
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -46,11 +46,11 @@ pub unsafe extern "C" fn request_context_message_ffi(context: Box<RequestContext
     (*Box::into_raw(context)).encapsulated_request.as_mut_ptr() as *mut u8
 }
 
-/// Return the number of bytes that the encapsulated request takes
+/// Return the size in bytes of the encapsulated request.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -64,11 +64,11 @@ pub struct ResponseContext {
     response: Vec<u8>,
 }
 
-/// Return the pointer to first byte of decapsulated response
+/// Return a pointer to the decapsulated response.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -76,11 +76,11 @@ pub unsafe extern "C" fn response_context_message_ffi(context: Box<ResponseConte
     (*Box::into_raw(context)).response.as_mut_ptr() as *mut u8
 }
 
-/// Return the number of bytes that the decapsulated response takes
+/// Return size in bytes of the decapsulated response.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -90,15 +90,16 @@ pub unsafe extern "C" fn response_context_message_len_ffi(
     (*Box::into_raw(context)).response.len()
 }
 
-/// Encapsulates the provided `encoded_msg` using `encoded_config`
+/// Encapsulates the provided `encoded_msg` using `encoded_config` and return
+/// a context used for decapsulating the corresponding response.
 ///
-/// This function will return `null` pointer if:
-///     - creating the request context fails ie due to parsing errors of configuration
-///     - encapsulation fails ie due to failed hpke encryption
+/// This function will return a NULL pointer if:
+///     - creating the request context fails due to input errors.
+///     - encapsulation fails.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -139,14 +140,13 @@ pub unsafe extern "C" fn encapsulate_request_ffi(
     Box::into_raw(ctx)
 }
 
-/// Decapsulates the provided `encapsulated_response` using `context`
+/// Decapsulates the provided `encapsulated_response` using `context`.
 ///
-/// This function will return `null` pointer if:
-///     - decapsulation fails ie due to failed hpke encryption
+/// This function will return a NULL pointer if decapsulation fails.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by user.
-/// Be sure that the context has not been yet freed and that you are using valid pointer
+/// This dereferences a raw pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -25,20 +25,20 @@ pub enum ClientError {
 }
 
 #[cfg(feature = "java")]
-mod android;
+pub mod android;
 
-mod error_ffi;
+pub mod error_ffi;
 
 pub struct RequestContext {
     encapsulated_request: Vec<u8>,
     response_context: ClientResponse,
 }
 
-// Return a pointer to encapsulated request
+/// Return a pointer to encapsulated request
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -49,8 +49,8 @@ pub unsafe extern "C" fn request_context_message_ffi(context: Box<RequestContext
 /// Return the size in bytes of the encapsulated request.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -60,6 +60,20 @@ pub unsafe extern "C" fn request_context_message_len_ffi(
     (*Box::into_raw(context)).encapsulated_request.len()
 }
 
+/// Frees up context memory. Be sure to call this in cases:
+/// - after encapsulating the HTTP request was not performed
+/// - the response has not been returned or is not successful
+///
+/// # Safety
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
+#[no_mangle]
+pub unsafe extern "C" fn request_context_message_drop_ffi(context: Box<RequestContext>) {
+    let _context = context;
+}
+
 pub struct ResponseContext {
     response: Vec<u8>,
 }
@@ -67,8 +81,8 @@ pub struct ResponseContext {
 /// Return a pointer to the decapsulated response.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -79,8 +93,8 @@ pub unsafe extern "C" fn response_context_message_ffi(context: Box<ResponseConte
 /// Return size in bytes of the decapsulated response.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -90,16 +104,16 @@ pub unsafe extern "C" fn response_context_message_len_ffi(
     (*Box::into_raw(context)).response.len()
 }
 
-/// Encapsulates the provided `encoded_msg` using `encoded_config` and return
+/// Encapsulates the provided `encoded_msg` using `encoded_config` and returns
 /// a context used for decapsulating the corresponding response.
 ///
 /// This function will return a NULL pointer if:
-///     - creating the request context fails due to input errors.
-///     - encapsulation fails.
+/// - creating the request context fails due to input errors.
+/// - encapsulation fails.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
@@ -145,8 +159,8 @@ pub unsafe extern "C" fn encapsulate_request_ffi(
 /// This function will return a NULL pointer if decapsulation fails.
 ///
 /// # Safety
-/// This dereferences a raw pointer to `RequestContext` passed by the caller.
-/// Be sure that the context has not been yet freed and that you are using valid pointer.
+/// Dereferences a pointer to `RequestContext` passed by the caller.
+/// Be sure that the context has not been yet freed and that you are using a valid pointer.
 ///
 /// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -1,22 +1,58 @@
 // Copyright (c) 2022 Cloudflare, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+use error_ffi::update_last_error;
 use ohttp::{ClientRequest, ClientResponse};
-use std::slice;
+use std::{ptr, slice};
 
- #[cfg(feature = "java")]
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("Failed to create request context")]
+    RequestContextInitialization(ohttp::Error),
+    #[error("Failed to encapsulate request")]
+    EncapsulationFailed(ohttp::Error),
+    #[error("Failed to decapsulate request")]
+    DecapsulationFailed(ohttp::Error),
+
+    #[error("Invalid argument `{0}` passed")]
+    InvalidArgument(String),
+
+    #[cfg(feature = "java")]
+    #[error("Unexpected JNI issue")]
+    JniProblem(jni::errors::Error),
+}
+
+#[cfg(feature = "java")]
 mod android;
+
+mod error_ffi;
 
 pub struct RequestContext {
     encapsulated_request: Vec<u8>,
     response_context: ClientResponse,
 }
 
+// Return the pointer to first byte of encapsulated request
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn request_context_message_ffi(context: Box<RequestContext>) -> *mut u8 {
     (*Box::into_raw(context)).encapsulated_request.as_mut_ptr() as *mut u8
 }
 
+/// Return the number of bytes that the encapsulated request takes
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn request_context_message_len_ffi(
     context: Box<RequestContext>,
@@ -28,11 +64,25 @@ pub struct ResponseContext {
     response: Vec<u8>,
 }
 
+/// Return the pointer to first byte of decapsulated response
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn response_context_message_ffi(context: Box<ResponseContext>) -> *mut u8 {
     (*Box::into_raw(context)).response.as_mut_ptr() as *mut u8
 }
 
+/// Return the number of bytes that the decapsulated response takes
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn response_context_message_len_ffi(
     context: Box<ResponseContext>,
@@ -40,38 +90,82 @@ pub unsafe extern "C" fn response_context_message_len_ffi(
     (*Box::into_raw(context)).response.len()
 }
 
+/// Encapsulates the provided `encoded_msg` using `encoded_config`
+///
+/// This function will return `null` pointer if:
+///     - creating the request context fails ie due to parsing errors of configuration
+///     - encapsulation fails ie due to failed hpke encryption
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn encapsulate_request_ffi(
     encoded_config_ptr: *const u8,
     encoded_config_len: libc::size_t,
     encoded_msg_ptr: *const u8,
     encoded_msg_len: libc::size_t,
-) -> Box<RequestContext> {
+) -> *mut RequestContext {
     let encoded_config: &[u8] =
         slice::from_raw_parts_mut(encoded_config_ptr as *mut u8, encoded_config_len as usize);
     let encoded_msg: &[u8] =
         slice::from_raw_parts_mut(encoded_msg_ptr as *mut u8, encoded_msg_len as usize);
-    let client = ClientRequest::new(encoded_config).unwrap();
-    let (enc_request, client_response) = client.encapsulate(encoded_msg).unwrap();
-    Box::new(RequestContext {
+
+    let client = match ClientRequest::new(encoded_config) {
+        Ok(c) => c,
+        Err(err) => {
+            let err = ClientError::RequestContextInitialization(err);
+            update_last_error(err);
+            return ptr::null_mut();
+        }
+    };
+
+    let (enc_request, client_response) = match client.encapsulate(encoded_msg) {
+        Ok(encapsulated) => encapsulated,
+        Err(err) => {
+            let err = ClientError::EncapsulationFailed(err);
+            update_last_error(err);
+            return ptr::null_mut();
+        }
+    };
+
+    let ctx = Box::new(RequestContext {
         encapsulated_request: enc_request,
         response_context: client_response,
-    })
+    });
+
+    Box::into_raw(ctx)
 }
 
+/// Decapsulates the provided `encapsulated_response` using `context`
+///
+/// This function will return `null` pointer if:
+///     - decapsulation fails ie due to failed hpke encryption
+///
+/// # Safety
+/// This dereferences a raw pointer to `RequestContext` passed by user.
+/// Be sure that the context has not been yet freed and that you are using valid pointer
+///
+/// <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 #[no_mangle]
 pub unsafe extern "C" fn decapsulate_response_ffi(
     context: Box<RequestContext>,
     encapsulated_response_ptr: *const u8,
     encapsulated_response_len: libc::size_t,
-) -> Box<ResponseContext> {
+) -> *mut ResponseContext {
     let encapsulated_response: &[u8] = slice::from_raw_parts_mut(
         encapsulated_response_ptr as *mut u8,
         encapsulated_response_len as usize,
     );
-    let response = context
-        .response_context
-        .decapsulate(encapsulated_response)
-        .unwrap();
-    Box::new(ResponseContext { response })
+    let response = match context.response_context.decapsulate(encapsulated_response) {
+        Ok(response) => response,
+        Err(err) => {
+            let err = ClientError::DecapsulationFailed(err);
+            update_last_error(err);
+            return ptr::null_mut();
+        }
+    };
+    Box::into_raw(Box::new(ResponseContext { response }))
 }


### PR DESCRIPTION
The style of error handling was inspired by https://michael-f-bryan.github.io/rust-ffi-guide/errors/index.html it holds errors in local thread storage and exposes functions `last_error_message` and `last_error_length` to access the messages over FFI. All functions return POSIX style return codes:

- `null` for references
- `-1` for longs and lengths

There are couple of things to consider:

- [ ] making it completely panic free by catching all errors using `std::panic::catch_unwind` checkout https://doc.rust-lang.org/nomicon/ffi.html#panic-can-be-stopped-at-an-abi-boundary but this seems like an overkill for non safety critical app
- [ ] if there is any possibility that some code will ever check the error messages from other thread than the one that resulted in the problem itself?

Closes #3 