### PR TITLE
Add std::panic::catch_unwind and logging for library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "cbindgen",
+ "env_logger 0.9.0",
  "jni",
  "libc",
  "log",
@@ -263,6 +273,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +396,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,7 +481,7 @@ dependencies = [
  "aead",
  "aes-gcm",
  "chacha20poly1305",
- "env_logger",
+ "env_logger 0.8.4",
  "hex",
  "hkdf",
  "hpke",
@@ -562,6 +591,23 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -678,6 +724,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ strip = true  # Automatically strip symbols from the binary.
 opt-level = "z"  # Optimize for size.
 lto = true  # Enable link time optimization
 codegen-units = 1  # Reduce parallel code generation units
-panic = "abort"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ class OHttpNativeWrapper {
     private static native void dropRequestContext(long ctx_ptr);
 
     private static native byte[] decapsulateResponse(long ctx_ptr, byte[] encapsulated_response);
+    
+    public static native String lastErrorMessage();
+
+    public static native void init();
+
+    public static native void drop(long ctx_ptr);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,6 @@ The library uses crate `env_logger` configured to log to stdout. To enable loggi
 RUST_LOG=debug
 ```
 
-And in your application be sure to call function `initialize_logging` for C api or `init` for jni.
+And in your application be sure to call function `initialize_logging` for C API or `init` for JNI.
 Initialization function can be called only once.
 

--- a/README.md
+++ b/README.md
@@ -151,3 +151,14 @@ To build binaries with a smaller disk footprint you can use the `release-space-o
 
 For more background about the parameters set for this profile read [this repo](https://github.com/johnthagen/min-sized-rust).
 
+## Logging in runtime
+
+The library uses crate `env_logger` configured to log to stdout. To enable logging set environment variable:
+
+```
+RUST_LOG=debug
+```
+
+And in your application be sure to call function `initialize_logging` for C api or `init` for jni.
+Initialization function can be called only once.
+

--- a/apprelay/Cargo.toml
+++ b/apprelay/Cargo.toml
@@ -13,6 +13,8 @@ libc = "0.2"
 thiserror = "1.0.32"
 log = "0.4.17"
 
+env_logger = "0.9.0"
+
 [dependencies.jni]
 version = "0.19.0"
 optional = true

--- a/apprelay/apprelay.h
+++ b/apprelay/apprelay.h
@@ -89,6 +89,8 @@ struct ResponseContext *decapsulate_response_ffi(struct RequestContext *context,
                                                  const uint8_t *encapsulated_response_ptr,
                                                  size_t encapsulated_response_len);
 
+void initialize_logging(void);
+
 // Return the number of bytes in the last error message.
 // Does not include any trailing null terminators.
 int last_error_length(void);

--- a/apprelay/src/android.rs
+++ b/apprelay/src/android.rs
@@ -22,6 +22,12 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_lastErrorMessage(
     }
 }
 
+/// Initialize logging
+#[no_mangle]
+pub extern "system" fn Java_org_platform_OHttpNativeWrapper_init(_env: JNIEnv, _class: JClass) {
+    crate::error_ffi::initialize_logging();
+}
+
 /// Encapsulates a request using the provided configuration.
 ///
 /// Returns a pointer to encapsulation context, and returns -1 upon failure.
@@ -60,8 +66,13 @@ pub extern "system" fn Java_org_platform_OHttpNativeWrapper_encapsulateRequest(
     };
 
     unsafe {
-        crate::encapsulate_request_ffi(config.as_ptr(), config.len(), msg.as_ptr(), msg.len())
-            as jlong
+        let encapsulated =
+            crate::encapsulate_request_ffi(config.as_ptr(), config.len(), msg.as_ptr(), msg.len());
+        if encapsulated.is_null() {
+            -1
+        } else {
+            encapsulated as jlong
+        }
     }
 }
 

--- a/apprelay/src/error_ffi.rs
+++ b/apprelay/src/error_ffi.rs
@@ -1,10 +1,21 @@
 use std::{cell::RefCell, error::Error, slice};
 
 use libc::{c_char, c_int};
-use log::error;
+use log::{error, debug};
+
+use env_logger::{Builder, Target};
 
 thread_local! {
     static LAST_ERROR: RefCell<Option<Box<dyn Error>>> = RefCell::new(None);
+}
+
+#[no_mangle]
+pub extern "C" fn initialize_logging() {
+    let mut builder = Builder::from_default_env();
+    builder.target(Target::Stdout);
+
+    builder.init();
+    debug!("Logger initialized");
 }
 
 /// Update the last error, clearing the old one.
@@ -58,7 +69,7 @@ pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) 
         None => return 0,
     };
 
-    let error_message = last_error.to_string();
+    let error_message = format!("my error {:?}", last_error);
 
     let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length as usize);
 

--- a/apprelay/src/error_ffi.rs
+++ b/apprelay/src/error_ffi.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn last_error_message(buffer: *mut c_char, length: c_int) 
         None => return 0,
     };
 
-    let error_message = format!("my error {:?}", last_error);
+    let error_message = last_error.to_string(); 
 
     let buffer = slice::from_raw_parts_mut(buffer as *mut u8, length as usize);
 

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -10,18 +10,18 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ClientError {
     #[error("Failed to create request context")]
-    RequestContextInitialization(ohttp::Error),
+    RequestContextInitialization(#[source] ohttp::Error),
     #[error("Failed to encapsulate request")]
-    EncapsulationFailed(ohttp::Error),
+    EncapsulationFailed(#[source] ohttp::Error),
     #[error("Failed to decapsulate request")]
-    DecapsulationFailed(ohttp::Error),
+    DecapsulationFailed(#[source] ohttp::Error),
 
     #[error("Invalid argument `{0}` passed")]
     InvalidArgument(String),
 
     #[cfg(feature = "java")]
     #[error("Unexpected JNI issue")]
-    JniProblem(jni::errors::Error),
+    JniProblem(#[source] jni::errors::Error),
 }
 
 #[cfg(feature = "java")]

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -3,7 +3,10 @@
 
 use error_ffi::update_last_error;
 use ohttp::{ClientRequest, ClientResponse};
+use std::any::Any;
 use std::{ptr, slice};
+
+use std::panic::catch_unwind;
 
 use thiserror::Error;
 
@@ -18,6 +21,9 @@ pub enum ClientError {
 
     #[error("Invalid argument `{0}` passed")]
     InvalidArgument(String),
+
+    #[error("Panic unwinded at {0:?}")]
+    SafePanic(Box<dyn Any + Send>),
 
     #[cfg(feature = "java")]
     #[error("Unexpected JNI issue")]
@@ -128,30 +134,39 @@ pub unsafe extern "C" fn encapsulate_request_ffi(
     let encoded_msg: &[u8] =
         slice::from_raw_parts_mut(encoded_msg_ptr as *mut u8, encoded_msg_len as usize);
 
-    let client = match ClientRequest::new(encoded_config) {
-        Ok(c) => c,
-        Err(err) => {
-            let err = ClientError::RequestContextInitialization(err);
-            update_last_error(err);
-            return ptr::null_mut();
-        }
-    };
+    let result = catch_unwind(|| {
+        let client = match ClientRequest::new(encoded_config) {
+            Ok(c) => c,
+            Err(err) => {
+                let err = ClientError::RequestContextInitialization(err);
+                update_last_error(err);
+                return ptr::null_mut();
+            }
+        };
 
-    let (enc_request, client_response) = match client.encapsulate(encoded_msg) {
-        Ok(encapsulated) => encapsulated,
-        Err(err) => {
-            let err = ClientError::EncapsulationFailed(err);
-            update_last_error(err);
-            return ptr::null_mut();
-        }
-    };
+        let (enc_request, client_response) = match client.encapsulate(encoded_msg) {
+            Ok(encapsulated) => encapsulated,
+            Err(err) => {
+                let err = ClientError::EncapsulationFailed(err);
+                update_last_error(err);
+                return ptr::null_mut();
+            }
+        };
 
-    let ctx = Box::new(RequestContext {
-        encapsulated_request: enc_request,
-        response_context: client_response,
+        let ctx = Box::new(RequestContext {
+            encapsulated_request: enc_request,
+            response_context: client_response,
+        });
+        Box::into_raw(ctx)
     });
-
-    Box::into_raw(ctx)
+    match result {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            let err = ClientError::SafePanic(err);
+            update_last_error(err);
+            ptr::null_mut()
+        }
+    }
 }
 
 /// Decapsulates the provided `encapsulated_response` using `context`.
@@ -173,13 +188,24 @@ pub unsafe extern "C" fn decapsulate_response_ffi(
         encapsulated_response_ptr as *mut u8,
         encapsulated_response_len as usize,
     );
-    let response = match context.response_context.decapsulate(encapsulated_response) {
-        Ok(response) => response,
+
+    let result = catch_unwind(|| {
+        let response = match context.response_context.decapsulate(encapsulated_response) {
+            Ok(response) => response,
+            Err(err) => {
+                let err = ClientError::DecapsulationFailed(err);
+                update_last_error(err);
+                return ptr::null_mut();
+            }
+        };
+        Box::into_raw(Box::new(ResponseContext { response }))
+    });
+    match result {
+        Ok(ctx) => ctx,
         Err(err) => {
-            let err = ClientError::DecapsulationFailed(err);
+            let err = ClientError::SafePanic(err);
             update_last_error(err);
-            return ptr::null_mut();
+            ptr::null_mut()
         }
-    };
-    Box::into_raw(Box::new(ResponseContext { response }))
+    }
 }


### PR DESCRIPTION
Catch unwind should deal with unexpected panics inside `ohttp` crate. 

Additionally added possibility to enable logging using env flag. Since ohttp crate is using `log` frontend it will log nicely all the messages in case of debugging.
Current implementation will return only the last error message to caller over FFI (all the errors added as source are iterated and logged using error level)