### PR TITLE
Fix double-free by clarifying context ownership in docs

### DIFF
--- a/apprelay/apprelay.h
+++ b/apprelay/apprelay.h
@@ -30,9 +30,14 @@ uint8_t *request_context_message_ffi(struct RequestContext *context);
 // <https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#dereferencing-a-raw-pointer>
 size_t request_context_message_len_ffi(struct RequestContext *context);
 
-// Frees up context memory. Be sure to call this in cases:
-// - after encapsulating the HTTP request was not performed
-// - the response has not been returned or is not successful
+// Frees up context memory. Call this ONLY if you did not call `decapsulate_response_ffi`.
+//
+// Use cases:
+// - After `encapsulate_request_ffi` if you decide not to send the request
+// - If the HTTP request itself failed (network error, etc.) before receiving a response
+//
+// Do NOT call this after `decapsulate_response_ffi` - that function always consumes
+// the context regardless of success or failure.
 //
 // # Safety
 // Dereferences a pointer to `RequestContext` passed by the caller.
@@ -78,7 +83,11 @@ struct RequestContext *encapsulate_request_ffi(const uint8_t *encoded_config_lis
 
 // Decapsulates the provided `encapsulated_response` using `context`.
 //
-// This function will return a NULL pointer if decapsulation fails.
+// This function **always consumes the context**, whether decapsulation succeeds or fails.
+// Do NOT call `request_context_message_drop_ffi` after calling this function.
+//
+// Returns a pointer to the decapsulated response on success, or NULL on failure.
+// On failure, call `last_error_message_ffi` to get error details.
 //
 // # Safety
 // Dereferences a pointer to `RequestContext` passed by the caller.

--- a/apprelay/src/android.rs
+++ b/apprelay/src/android.rs
@@ -83,9 +83,14 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_getEncapsulat
     )
 }
 
-/// Frees up context memory. Be sure to call this in cases:
-/// - after encapsulating the HTTP request was not performed
-/// - the response has not been returned or is not successful
+/// Frees up context memory. Call this ONLY if you did not call `decapsulateResponse`.
+///
+/// Use cases:
+/// - After `encapsulateRequest` if you decide not to send the request
+/// - If the HTTP request itself failed (network error, etc.) before receiving a response
+///
+/// Do NOT call this after `decapsulateResponse` - that function always consumes
+/// the context regardless of success or failure.
 ///
 /// # Safety
 /// Dereferences a pointer to `RequestContext` passed by the caller.
@@ -102,11 +107,13 @@ pub unsafe extern "system" fn Java_org_platform_OHttpNativeWrapper_drop(
 }
 
 /// Decapsulates the provided response `encapsulated_response` using
-/// requests config obtain by dereferencing `context_ptr`
+/// requests config obtained by dereferencing `context_ptr`.
 ///
-/// Returns an array containing the decapsulated response.
+/// This function **always consumes the context**, whether decapsulation succeeds or fails.
+/// Do NOT call `drop` after calling this function.
 ///
-/// If this function fails due JNI problems or decapsulation it returns a NULL pointer.
+/// Returns an array containing the decapsulated response on success, or NULL on failure.
+/// On failure, call `lastErrorMessage` to get error details.
 ///
 /// # Safety
 /// Dereferences a pointer to `RequestContext` passed by the caller.

--- a/apprelay/src/lib.rs
+++ b/apprelay/src/lib.rs
@@ -123,9 +123,14 @@ pub unsafe extern "C" fn request_context_message_len_ffi(
     )
 }
 
-/// Frees up context memory. Be sure to call this in cases:
-/// - after encapsulating the HTTP request was not performed
-/// - the response has not been returned or is not successful
+/// Frees up context memory. Call this ONLY if you did not call `decapsulate_response_ffi`.
+///
+/// Use cases:
+/// - After `encapsulate_request_ffi` if you decide not to send the request
+/// - If the HTTP request itself failed (network error, etc.) before receiving a response
+///
+/// Do NOT call this after `decapsulate_response_ffi` - that function always consumes
+/// the context regardless of success or failure.
 ///
 /// # Safety
 /// Dereferences a pointer to `RequestContext` passed by the caller.
@@ -196,12 +201,17 @@ pub unsafe extern "C" fn encapsulate_request_ffi(
     encoded_msg_ptr: *const u8,
     encoded_msg_len: libc::size_t,
 ) -> *mut RequestContext {
-    let encoded_config_list_ptr =
-        null_safe_ptr!(encoded_config_list_ptr, ptr::null_mut(), encoded_config_list_ptr);
+    let encoded_config_list_ptr = null_safe_ptr!(
+        encoded_config_list_ptr,
+        ptr::null_mut(),
+        encoded_config_list_ptr
+    );
     let encoded_msg_ptr = null_safe_ptr!(encoded_msg_ptr, ptr::null_mut(), encoded_msg_ptr);
 
-    let encoded_config_list: &[u8] =
-        slice::from_raw_parts_mut(encoded_config_list_ptr as *mut u8, encoded_config_list_len as usize);
+    let encoded_config_list: &[u8] = slice::from_raw_parts_mut(
+        encoded_config_list_ptr as *mut u8,
+        encoded_config_list_len as usize,
+    );
     let encoded_msg: &[u8] =
         slice::from_raw_parts_mut(encoded_msg_ptr as *mut u8, encoded_msg_len as usize);
 
@@ -231,7 +241,11 @@ pub unsafe extern "C" fn encapsulate_request_ffi(
 
 /// Decapsulates the provided `encapsulated_response` using `context`.
 ///
-/// This function will return a NULL pointer if decapsulation fails.
+/// This function **always consumes the context**, whether decapsulation succeeds or fails.
+/// Do NOT call `request_context_message_drop_ffi` after calling this function.
+///
+/// Returns a pointer to the decapsulated response on success, or NULL on failure.
+/// On failure, call `last_error_message_ffi` to get error details.
 ///
 /// # Safety
 /// Dereferences a pointer to `RequestContext` passed by the caller.
@@ -244,11 +258,7 @@ pub unsafe extern "C" fn decapsulate_response_ffi(
     encapsulated_response_ptr: *const u8,
     encapsulated_response_len: libc::size_t,
 ) -> *mut ResponseContext {
-    let context = null_safe_ptr!(
-        context,
-        null_mut(),
-        Box::from_raw(context)
-    );
+    let context = null_safe_ptr!(context, null_mut(), Box::from_raw(context));
 
     let encapsulated_response_ptr = null_safe_ptr!(
         encapsulated_response_ptr,


### PR DESCRIPTION
decapsulate_response_ffi always consumes the context, whether decapsulation succeeds or fails. The previous documentation incorrectly instructed callers to free the context on error, which caused a double-free.

Updated docs for:
- request_context_message_drop_ffi (C FFI)
- decapsulate_response_ffi (C FFI)
- drop (Android JNI)
- decapsulateResponse (Android JNI)

The fix clarifies that callers should NOT call the drop/free function after calling decapsulate, regardless of the result.