### PR TITLE
docs: clarify code is for demonstration purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sample Privacy Gateway Client Library
 
-This project contains a sample library that exposes [OHTTP](https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp-02) client-side interfaces for iOS and macOS. It is compatible with the sample [relay](https://github.com/cloudflare/privacy-gateway-relay) and corresponding [server](https://github.com/cloudflare/privacy-gateway-server-go).
+This project contains a sample library that exposes [OHTTP](https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp-02) client-side interfaces for iOS and macOS. It is compatible with the sample [relay](https://github.com/cloudflare/privacy-gateway-relay) and corresponding [server](https://github.com/cloudflare/privacy-gateway-server-go). This code is provided for demonstration purposes.
 
 ## Build instructions
 


### PR DESCRIPTION
Adds clarification to README that this code is provided for demonstration purposes.